### PR TITLE
add source publication

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,10 +14,14 @@ path = "rust/lib.rs"
 build-java-support = []
 
 [dependencies]
-jni = "0.19.0"
+#jni = "0.19.0"
+jni = { path = "../jni-rs" }
 static_assertions = "1.1.0"
 uuid = "0.8.2"
 futures = "0.3.15"
+dashmap = "5.2.0"
+once_cell = "1.10.0"
+log = "0.4.16"
 
 [dev-dependencies]
 lazy_static = "1.4.0"

--- a/rust/classcache.rs
+++ b/rust/classcache.rs
@@ -1,0 +1,17 @@
+use jni::{JNIEnv, objects::GlobalRef};
+use once_cell::sync::OnceCell;
+use dashmap::DashMap;
+use ::jni::{errors::Result};
+
+static CLASSCACHE: OnceCell<DashMap<String, GlobalRef>> = OnceCell::new();
+
+pub fn find_add_class(env: &JNIEnv, classname: &str) -> Result<()> {
+  let cache = CLASSCACHE.get_or_init(|| DashMap::new());
+  cache.insert(classname.to_owned(), env.new_global_ref(env.find_class(classname).unwrap()).unwrap());
+  Ok(())
+}
+
+pub fn get_class(classname: &str) -> Option<GlobalRef> {
+  let cache = CLASSCACHE.get_or_init(|| DashMap::new());
+  cache.get(classname).and_then(|pair| Some(pair.value().clone()))
+}

--- a/rust/future.rs
+++ b/rust/future.rs
@@ -1,7 +1,7 @@
 use crate::task::JPollResult;
 use ::jni::{
     errors::{Error, Result},
-    objects::{GlobalRef, JMethodID, JObject},
+    objects::{GlobalRef, JMethodID, JObject, JClass},
     signature::JavaType,
     JNIEnv, JavaVM,
 };
@@ -38,10 +38,8 @@ impl<'a: 'b, 'b> JFuture<'a, 'b> {
     /// * `env` - Java environment to use.
     /// * `obj` - Object to wrap.
     pub fn from_env(env: &'b JNIEnv<'a>, obj: JObject<'a>) -> Result<Self> {
-        let class = env.auto_local(env.find_class("io/github/gedgygedgy/rust/future/Future")?);
-
         let poll = env.get_method_id(
-            &class,
+            JClass::from(crate::classcache::get_class("io/github/gedgygedgy/rust/future/Future").unwrap().as_obj()),
             "poll",
             "(Lio/github/gedgygedgy/rust/task/Waker;)Lio/github/gedgygedgy/rust/task/PollResult;",
         )?;

--- a/rust/lib.rs
+++ b/rust/lib.rs
@@ -42,6 +42,7 @@
 use ::jni::{errors::Result, JNIEnv};
 
 pub mod arrays;
+pub mod classcache;
 pub mod exceptions;
 pub mod future;
 pub mod ops;

--- a/rust/stream.rs
+++ b/rust/stream.rs
@@ -1,7 +1,7 @@
 use crate::task::JPollResult;
 use ::jni::{
     errors::{Error, Result},
-    objects::{GlobalRef, JMethodID, JObject},
+    objects::{GlobalRef, JMethodID, JObject, JClass},
     signature::JavaType,
     JNIEnv, JavaVM,
 };
@@ -38,10 +38,8 @@ impl<'a: 'b, 'b> JStream<'a, 'b> {
     /// * `env` - Java environment to use.
     /// * `obj` - Object to wrap.
     pub fn from_env(env: &'b JNIEnv<'a>, obj: JObject<'a>) -> Result<Self> {
-        let class = env.auto_local(env.find_class("io/github/gedgygedgy/rust/stream/Stream")?);
-
         let poll_next = env.get_method_id(
-            &class,
+            JClass::from(crate::classcache::get_class("io/github/gedgygedgy/rust/stream/Stream").unwrap().as_obj()),
             "pollNext",
             "(Lio/github/gedgygedgy/rust/task/Waker;)Lio/github/gedgygedgy/rust/task/PollResult;",
         )?;
@@ -173,9 +171,10 @@ struct JStreamPoll<'a: 'b, 'b> {
 
 impl<'a: 'b, 'b> JStreamPoll<'a, 'b> {
     pub fn from_env(env: &'b JNIEnv<'a>, obj: JObject<'a>) -> Result<Self> {
-        let class = env.auto_local(env.find_class("io/github/gedgygedgy/rust/stream/StreamPoll")?);
-
-        let get = env.get_method_id(&class, "get", "()Ljava/lang/Object;")?;
+        let get = env.get_method_id(
+            JClass::from(crate::classcache::get_class("io/github/gedgygedgy/rust/stream/StreamPoll").unwrap().as_obj()),
+            "get", 
+            "()Ljava/lang/Object;")?;
         Ok(Self {
             internal: obj,
             get,


### PR DESCRIPTION
For using in a maven repository. We only need to add this line to publish the artefacts. It the line is not present, only the pom is published, leading to missing classes (i.e. in btleplug/droidplug)